### PR TITLE
update test.js and index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const isEmpty = function (value) {
    var remSpace = value.toString().replace(/\s/gi, "");
    return (
        !value ||
-       value == "0" ||
+       value === "0" ||
        0 === value.length ||
        Object.entries(value).length === 0 &&
        value.constructor === Object ||

--- a/index.js
+++ b/index.js
@@ -1,17 +1,25 @@
 /**
  * Author: https://github.com/haryanapnx
- * @param {*} value 
+ * @param {*} value
  * @returns {boolean}
  */
 
 /**
  * This function will checking for value that
  * passed into parameter, and check the value
- * 
+ *
  * if value {null}, {undefined}, {0}, {''}
  * will returns true
  */
 const isEmpty = function (value) {
-   return (!value || value == "0" || 0 === value.length || Object.entries(value).length === 0 && value.constructor === Object);
-}
-module.exports = isEmpty
+   var remSpace = value.toString().replace(/\s/gi, "");
+   return (
+       !value ||
+       value == "0" ||
+       0 === value.length ||
+       Object.entries(value).length === 0 &&
+       value.constructor === Object ||
+       remSpace === ""
+   );
+};
+module.exports = isEmpty;

--- a/test.js
+++ b/test.js
@@ -2,16 +2,18 @@ const isEmpty = require('./index')
 const assert = require('assert')
 
 // true when value = 0
-assert.equal(true, isEmpty(0), '0 is empty');
+assert.strictEqual(true, isEmpty(0), '0 is empty');
 // true when value = ""
-assert.equal(true, isEmpty(""), '"" is empty');
+assert.strictEqual(true, isEmpty(""), '"" is empty');
 // false when value = "1"
-assert.equal(false, isEmpty(1), '1 is not empty');
+assert.strictEqual(false, isEmpty(1), '1 is not empty');
 // true when value = "0"
-assert.equal(true, isEmpty("0"), '0 is empty');
+assert.strictEqual(true, isEmpty("0"), '0 is empty');
 // true when value  = {}
-assert.equal(true, isEmpty({}), '{} is empty');
+assert.strictEqual(true, isEmpty({}), '{} is empty');
 // true when value  = " "
-assert.equal(true, isEmpty(" "), '" " is empty');
+assert.strictEqual(true, isEmpty(" "), '" " is empty');
 // false when value  = " a s d  "
-assert.equal(false, isEmpty(" a s d "), '" a s d " is not empty');
+assert.strictEqual(false, isEmpty(" a s d "), '" a s d " is not empty');
+
+console.log("test running successfully");

--- a/test.js
+++ b/test.js
@@ -11,3 +11,7 @@ assert.equal(false, isEmpty(1), '1 is not empty');
 assert.equal(true, isEmpty("0"), '0 is empty');
 // true when value  = {}
 assert.equal(true, isEmpty({}), '{} is empty');
+// true when value  = " "
+assert.equal(true, isEmpty(" "), '" " is empty');
+// false when value  = " a s d  "
+assert.equal(false, isEmpty(" a s d "), '" a s d " is not empty');


### PR DESCRIPTION
test.js : 
change assert.equal to assert.strictEqual 
[NodeJS] assert.equal() is deprecated since node v10
https://github.com/googleapis/gapic-generator/issues/2154

index.js : 
change (value == "0") to (value === "0")